### PR TITLE
chore: add a missing unit test

### DIFF
--- a/apis/v1beta1/testdata/config-override-with-unknown-fields.yaml
+++ b/apis/v1beta1/testdata/config-override-with-unknown-fields.yaml
@@ -1,0 +1,14 @@
+secretData:
+  config.yaml: |
+    apiVersion: embeddedcluster.replicated.com/v1beta1
+    kind: Config
+    spec:
+      version: 1.29.1+ec.100
+      this:
+        is:
+          an:
+            unknown: field
+configSpec:
+  version: 1.29.1+ec.1
+expected:
+  version: 1.29.1+ec.100


### PR DESCRIPTION
make sure we keep working even if the config contains unknown fields.