### PR TITLE
feat: return error if secret does not contain config entry

### DIFF
--- a/apis/v1beta1/installation_types.go
+++ b/apis/v1beta1/installation_types.go
@@ -109,7 +109,12 @@ type InstallationSpec struct {
 func (i *InstallationSpec) ParseConfigSpecFromSecret(secret corev1.Secret) error {
 	data, ok := secret.Data[ConfigSecretEntryName]
 	if !ok {
-		return nil
+		return fmt.Errorf(
+			"entry %s not found in secret %s/%s",
+			ConfigSecretEntryName,
+			secret.Namespace,
+			secret.Name,
+		)
 	}
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {

--- a/apis/v1beta1/installation_types_test.go
+++ b/apis/v1beta1/installation_types_test.go
@@ -13,6 +13,7 @@ func TestParseConfigSpecFromSecret(t *testing.T) {
 		SecretData map[string]string `yaml:"secret"`
 		ConfigSpec *ConfigSpec       `yaml:"configSpec"`
 		Expected   *ConfigSpec       `yaml:"expected"`
+		Error      string            `yaml:"error"`
 	}
 
 	for tname, tt := range parseTestsYAML[test](t, "config-override-") {
@@ -24,8 +25,12 @@ func TestParseConfigSpecFromSecret(t *testing.T) {
 			for k, v := range tt.SecretData {
 				secret.Data[k] = []byte(v)
 			}
-			err := in.ParseConfigSpecFromSecret(secret)
-			require.NoError(t, err)
+			if err := in.ParseConfigSpecFromSecret(secret); err != nil {
+				require.NotEmpty(t, tt.Error, "unexpected error: %v", err)
+				require.Contains(t, err.Error(), tt.Error)
+				return
+			}
+			require.Empty(t, tt.Error, "expected error: %v", tt.Error)
 			require.Equal(t, tt.Expected, in.Config)
 		})
 	}

--- a/apis/v1beta1/testdata/config-override-no-entry.yaml
+++ b/apis/v1beta1/testdata/config-override-no-entry.yaml
@@ -3,5 +3,4 @@ secretData:
     test: value
 configSpec:
   version: 1.7.0
-expected:
-  version: 1.7.0
+error: entry config.yaml not found in secret


### PR DESCRIPTION
if the config entry was not found in the secret we must return an error.