### PR TITLE
add isHighAvailability field to installation spec

### DIFF
--- a/apis/v1beta1/installation_types.go
+++ b/apis/v1beta1/installation_types.go
@@ -84,7 +84,7 @@ type InstallationSpec struct {
 	// MetricsBaseURL holds the base URL for the metrics server.
 	MetricsBaseURL string `json:"metricsBaseURL,omitempty"`
 	// IsHighAvailability indicates if the installation is high availability.
-	IsHighAvailability bool `json:"isHighAvailability,omitempty"`
+	IsHighAvailability bool `json:"isHighAvailability"`
 	// AirGap indicates if the installation is airgapped.
 	AirGap bool `json:"airGap"`
 	// Artifacts holds the location of the airgap bundle.

--- a/apis/v1beta1/installation_types.go
+++ b/apis/v1beta1/installation_types.go
@@ -83,6 +83,8 @@ type InstallationSpec struct {
 	ClusterID string `json:"clusterID,omitempty"`
 	// MetricsBaseURL holds the base URL for the metrics server.
 	MetricsBaseURL string `json:"metricsBaseURL,omitempty"`
+	// IsHighAvailability indicates if the installation is high availability.
+	IsHighAvailability bool `json:"isHighAvailability,omitempty"`
 	// AirGap indicates if the installation is airgapped.
 	AirGap bool `json:"airGap"`
 	// Artifacts holds the location of the airgap bundle.


### PR DESCRIPTION
This PR adds an `isHighAvailability` to the spec of the Installation kind to indicate whether the embedded cluster installation is configured for high-availability.