### PR TITLE
omitempty installation spec fields

### DIFF
--- a/apis/v1beta1/installation_types.go
+++ b/apis/v1beta1/installation_types.go
@@ -84,9 +84,9 @@ type InstallationSpec struct {
 	// MetricsBaseURL holds the base URL for the metrics server.
 	MetricsBaseURL string `json:"metricsBaseURL,omitempty"`
 	// IsHighAvailability indicates if the installation is high availability.
-	IsHighAvailability bool `json:"isHighAvailability"`
+	IsHighAvailability bool `json:"isHighAvailability,omitempty"`
 	// AirGap indicates if the installation is airgapped.
-	AirGap bool `json:"airGap"`
+	AirGap bool `json:"airGap,omitempty"`
 	// Artifacts holds the location of the airgap bundle.
 	Artifacts *ArtifactsLocation `json:"artifacts,omitempty"`
 	// Config holds the configuration used at installation time.


### PR DESCRIPTION
Adds `omitempty` to the `airGap` and `isHighAvailability` Installation spec fields