### PR TITLE
feat: restore airgap config field

### DIFF
--- a/types/release_metadata.go
+++ b/types/release_metadata.go
@@ -13,4 +13,8 @@ type ReleaseMetadata struct {
 	Configs        v1beta1.HelmExtensions            // always applied
 	BuiltinConfigs map[string]v1beta1.HelmExtensions // applied if the relevant builtin addon is enabled
 	Protected      map[string][]string
+
+	// Deprecated: AirgapConfigs exists for historical compatibility and should not
+	// be used. This field has been replaced by the BuiltinConfigs field.
+	AirgapConfigs v1beta1.HelmExtensions
 }


### PR DESCRIPTION
this field is used by old ec versions and won't be away, for a while at least.