### PR TITLE
feat: add ReleaseMetadata.Images field to keep track of all images in release

### DIFF
--- a/types/release_metadata.go
+++ b/types/release_metadata.go
@@ -12,7 +12,8 @@ type ReleaseMetadata struct {
 	K0sSHA         string
 	K0sBinaryURL   string
 	Artifacts      map[string]string // key is the artifact name, value is the URL it can be retrieved from
-	K0sImages      []string
+	Images         []string
+	K0sImages      []string                // deprecated (still used by airgap-builder), use Images instead
 	Configs        v1beta1.Helm            // always applied
 	BuiltinConfigs map[string]v1beta1.Helm // applied if the relevant builtin addon is enabled
 	Protected      map[string][]string


### PR DESCRIPTION
ReleaseMetadata.Images is a new field that will contain all images in an embedded cluster binary release. K0sImages does not include images from helm charts.